### PR TITLE
feat(subscription): add APIs for lawyer subscription details and upgrade handling

### DIFF
--- a/src/application/dtos/user/ResponseGetSingleLawyerDTO.ts
+++ b/src/application/dtos/user/ResponseGetSingleLawyerDTO.ts
@@ -15,6 +15,7 @@ export class ResponseGetSingleLawyerDTO {
   phone: string;
   profileImage: string;
   bio: string;
+  consultationFee:number
 
   constructor(data: any) {
     this.id = String(data.id);
@@ -35,5 +36,6 @@ export class ResponseGetSingleLawyerDTO {
 
     this.profileImage = data.profileImage || "";
     this.bio = data.bio || "";
+    this.consultationFee = data.consultationFee
   }
 }

--- a/src/application/interface/use-cases/lawyer/IGetCurrentSubscriptionUseCase.ts
+++ b/src/application/interface/use-cases/lawyer/IGetCurrentSubscriptionUseCase.ts
@@ -1,0 +1,5 @@
+import { SubscriptionDTO } from "../../../dtos/lawyer/SubscriptionDTO" 
+ 
+ export interface IGetCurrentSubscriptionUseCase{
+    execute(lawyerId:string):Promise<SubscriptionDTO|null>
+ }

--- a/src/application/interface/use-cases/lawyer/IGetSubscriptionPlansUseCase.ts
+++ b/src/application/interface/use-cases/lawyer/IGetSubscriptionPlansUseCase.ts
@@ -1,0 +1,6 @@
+import { SubscriptionDTO } from "../../../dtos/lawyer/SubscriptionDTO"
+
+
+export interface IGetSubscriptionPlansUseCase {
+    execute():Promise<SubscriptionDTO[]>
+}

--- a/src/application/useCases/lawyer/GetCurrentSubscriptionUseCase.ts
+++ b/src/application/useCases/lawyer/GetCurrentSubscriptionUseCase.ts
@@ -1,0 +1,29 @@
+import { ISubscriptionRepository } from "../../../domain/repositories/admin/ISubscriptionRepository";
+import { ILawyerRepository } from "../../../domain/repositories/lawyer/ILawyerRepository";
+import { SubscriptionDTO } from "../../dtos/lawyer/SubscriptionDTO";
+import { SubscriptionMapper } from "../../mapper/lawyer/SubscriptionMapper";
+import { IGetCurrentSubscriptionUseCase } from "../../interface/use-cases/lawyer/IGetCurrentSubscriptionUseCase";
+
+
+
+
+export class GetCurrentSubscriptionUseCase implements IGetCurrentSubscriptionUseCase {
+    constructor(
+        private lawyerRepository: ILawyerRepository,
+        private subscriptionRepository: ISubscriptionRepository
+    ) { }
+
+    async execute(lawyerId: string): Promise<SubscriptionDTO | null> {
+        const lawyer = await this.lawyerRepository.findById(lawyerId);
+        if (!lawyer || !lawyer.subscriptionId) {
+            return null;
+        }
+
+        const subscription = await this.subscriptionRepository.findById(lawyer.subscriptionId);
+        if (!subscription) {
+            return null;
+        }
+
+        return SubscriptionMapper.toDTO(subscription);
+    }
+}

--- a/src/application/useCases/lawyer/GetSubscriptionPlansUseCase.ts
+++ b/src/application/useCases/lawyer/GetSubscriptionPlansUseCase.ts
@@ -1,8 +1,11 @@
 import { ISubscriptionRepository } from "../../../domain/repositories/admin/ISubscriptionRepository";
 import { SubscriptionDTO } from "../../dtos/lawyer/SubscriptionDTO";
 import { SubscriptionMapper } from "../../mapper/lawyer/SubscriptionMapper";
+import { IGetSubscriptionPlansUseCase } from "../../interface/use-cases/lawyer/IGetSubscriptionPlansUseCase";
 
-export class GetSubscriptionPlansUseCase {
+
+
+export class GetSubscriptionPlansUseCase implements IGetSubscriptionPlansUseCase {
     constructor(private subscriptionRepository: ISubscriptionRepository) { }
 
     async execute(): Promise<SubscriptionDTO[]> {

--- a/src/domain/entities/ User.ts
+++ b/src/domain/entities/ User.ts
@@ -17,16 +17,3 @@ export interface User {
   verificationStatus?: string
 }
 
-// export class User {
-//   constructor(
-//     public id: string,
-//     public name: string,
-//     public email: string,
-//     public password: string,
-//     public phone: number,
-//     public isVerified: boolean,
-//     public role: string,
-//     public isBlock: boolean,
-//     public hasSubmittedVerification: boolean
-//   ) { }
-// }

--- a/src/interface/controllers/lawyer/SubscriptionController.ts
+++ b/src/interface/controllers/lawyer/SubscriptionController.ts
@@ -1,13 +1,32 @@
 import { Request, Response, NextFunction } from "express";
-import { GetSubscriptionPlansUseCase } from "../../../application/useCases/lawyer/GetSubscriptionPlansUseCase";
+import { IGetSubscriptionPlansUseCase } from "../../../application/interface/use-cases/lawyer/IGetSubscriptionPlansUseCase";
 import { HttpStatusCode } from "../../../infrastructure/interface/enums/HttpStatusCode";
+import { IGetCurrentSubscriptionUseCase } from "../../../application/interface/use-cases/lawyer/IGetCurrentSubscriptionUseCase";
+
 export class SubscriptionController {
-    constructor(private getSubscriptionPlansUseCase: GetSubscriptionPlansUseCase) { }
+    constructor(
+        private getSubscriptionPlansUseCase: IGetSubscriptionPlansUseCase,
+        private getCurrentSubscriptionUseCase: IGetCurrentSubscriptionUseCase
+    ) { }
 
     async getPlans(_req: Request, res: Response, next: NextFunction): Promise<void> {
         try {
             const plans = await this.getSubscriptionPlansUseCase.execute();
             res.status(HttpStatusCode.OK).json({ status: true, data: plans });
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    async getCurrentSubscription(req: Request, res: Response, next: NextFunction): Promise<void> {
+        try {
+            const lawyerId = req.user?.id;
+            if (!lawyerId) {
+                res.status(HttpStatusCode.UNAUTHORIZED).json({ status: false, message: "Unauthorized" });
+                return;
+            }
+            const subscription = await this.getCurrentSubscriptionUseCase.execute(lawyerId);
+            res.status(HttpStatusCode.OK).json({ status: true, data: subscription });
         } catch (error) {
             next(error);
         }

--- a/src/interface/routes/lawyer/lawyerRoutes.ts
+++ b/src/interface/routes/lawyer/lawyerRoutes.ts
@@ -30,6 +30,7 @@ import { ChangePasswordUseCase } from "../../../application/useCases/lawyer/Chan
 import { GetAppoimentsUseCase } from "../../../application/useCases/lawyer/GetAppoimentsUseCase";
 import { UpdateAppointmentStatusUseCase } from "../../../application/useCases/lawyer/UpdateAppointmentStatusUseCase";
 import { GetSubscriptionPlansUseCase } from "../../../application/useCases/lawyer/GetSubscriptionPlansUseCase";
+import { GetCurrentSubscriptionUseCase } from "../../../application/useCases/lawyer/GetCurrentSubscriptionUseCase";
 import { CreateSubscriptionCheckoutUseCase } from "../../../application/useCases/lawyer/CreateSubscriptionCheckoutUseCase";
 import { VerifySubscriptionPaymentUseCase } from "../../../application/useCases/lawyer/VerifySubscriptionPaymentUseCase";
 import { SubscriptionPaymentController } from "../../controllers/lawyer/SubscriptionPaymentController";
@@ -81,10 +82,11 @@ const stripeService = new StripeService();
 const paymentRepository = new PaymentRepository();
 
 const getSubscriptionPlansUseCase = new GetSubscriptionPlansUseCase(subscriptionRepository);
+const getCurrentSubscriptionUseCase = new GetCurrentSubscriptionUseCase(lawyerRepository, subscriptionRepository);
 const createSubscriptionCheckoutUseCase = new CreateSubscriptionCheckoutUseCase(stripeService);
 const verifySubscriptionPaymentUseCase = new VerifySubscriptionPaymentUseCase(stripeService, lawyerRepository, paymentRepository);
 
-const subscriptionController = new SubscriptionController(getSubscriptionPlansUseCase);
+const subscriptionController = new SubscriptionController(getSubscriptionPlansUseCase, getCurrentSubscriptionUseCase);
 const subscriptionPaymentController = new SubscriptionPaymentController(createSubscriptionCheckoutUseCase, verifySubscriptionPaymentUseCase);
 
 
@@ -202,6 +204,7 @@ router.post("/chat/room", lawyerAuthMiddleware.execute, (req, res, next) => chat
 
 
 router.get('/subscriptions', lawyerAuthMiddleware.execute, (req, res, next) => subscriptionController.getPlans(req, res, next));
+router.get('/subscription/current', lawyerAuthMiddleware.execute, (req, res, next) => subscriptionController.getCurrentSubscription(req, res, next));
 router.post('/subscription/checkout', lawyerAuthMiddleware.execute, (req, res, next) => subscriptionPaymentController.createCheckout(req, res, next));
 router.post('/subscription/success', lawyerAuthMiddleware.execute, (req, res, next) => subscriptionPaymentController.handleSuccess(req, res, next));
 


### PR DESCRIPTION
### What was implemented
- API to fetch current active subscription for a lawyer
- API to list available subscription plans
- Handle subscription upgrade logic on backend
- Validate upgrade eligibility and plan transitions
- Persist updated subscription state

